### PR TITLE
탭바 MY 아이콘 수정

### DIFF
--- a/lib/pages/tab.dart
+++ b/lib/pages/tab.dart
@@ -8,6 +8,7 @@ import 'package:hanjul_front/queries/search_words.dart';
 import 'package:hanjul_front/queries/see_my_profile.dart';
 import 'package:hanjul_front/pages/search.dart';
 import 'package:hanjul_front/config/utils.dart';
+import 'package:hanjul_front/widgets/user_avatar.dart';
 
 class TabPage extends StatefulWidget {
   TabPage({Key? key, this.onLoggedOut});
@@ -97,7 +98,26 @@ class _TabPageState extends State<TabPage> {
           BottomNavigationBarItem(
               icon: Icon(Icons.search, size: 32), label: "검색"),
           BottomNavigationBarItem(
-              icon: Icon(Icons.account_circle, size: 32), label: "MY")
+              icon: _me?['avatar'] == null
+                  ? Icon(Icons.account_circle, size: 32)
+                  : UserAvatar(
+                      avatar: _me?['avatar'],
+                      size: 32.0,
+                    ),
+              activeIcon: Container(
+                width: 32,
+                height: 32,
+                decoration: BoxDecoration(
+                  border: Border.all(width: 2, color: Colors.white),
+                  shape: BoxShape.circle,
+                  color: Colors.white,
+                ),
+                child: UserAvatar(
+                  avatar: _me?['avatar'],
+                  size: 32.0,
+                ),
+              ),
+              label: "MY")
         ],
       ),
     );


### PR DESCRIPTION
## 개발 내용
### 탭바 MY 아이콘 수정
- 로그인 유저가 프로필 사진을 가지고 있을 때, 탭바 MY 아이콘으로 유저의 프로필 사진을 표시
- 내 프로필 페이지에 있을 때, 탭바 MY 아이콘에 둥근 흰색 경계선 표시
- 로그인 유저가 프로필 사진을 가지고 있지 않다면, 기본 이미지 표시

close #8 